### PR TITLE
fixing screwed up branch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 ## [Unreleased]
+## [0.5.?] 2024-01-12
+- fixing screwed up branch
+
 ## [0.5.0] 2024-01-05
 - breaking changes:
     - changed `--config` to `--config_file`


### PR DESCRIPTION
I have a bunch on non-working junk in the `refactor_chat` branch that got committed to the `main` branch by accident.  I'm trying to recover from this problem by returning to tag v0.5.0 and commit that tag's content to `main`
