### PR TITLE
updated the completion functions.  bumped version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 ## [Unreleased]
+- Fixed completion functions by updating $PROMPT_DIR to $AIA_PROMPTS_DIR to match the documentation.
+
 ## [0.5.0] 2024-01-05
 - breaking changes:
     - changed `--config` to `--config_file`

--- a/lib/aia/aia_completion.bash
+++ b/lib/aia/aia_completion.bash
@@ -3,7 +3,7 @@
 # the bash shell
 #
 # This script assumes that the system environment
-# variable PROMPTS_DIR has been set correctly
+# variable AIA_PROMPTS_DIR has been set correctly
 
 _aia_completion() {
   # The current word being completed
@@ -18,7 +18,7 @@ _aia_completion() {
   # Check if we are currently completing the option that requires prompt IDs
   if [[ "$prev_word" == "aia" ]]; then
     # Change directory to the prompts directory
-    cd "$PROMPTS_DIR" || return
+    cd "$AIA_PROMPTS_DIR" || return
 
     # Generate a list of relative paths from the ~/.prompts directory (without .txt extension)
     local files=($(find . -name "*.txt" -type f | sed 's|^\./||' | sed 's/\.txt$//'))

--- a/lib/aia/aia_completion.fish
+++ b/lib/aia/aia_completion.fish
@@ -2,7 +2,7 @@
 # Setup a prompt completion for use with the fish shell
 #
 # This script assumes that the system environment
-# variable PROMPTS_DIR has been set correctly
+# variable AIA_PROMPTS_DIR has been set correctly
 
 function __fish_aia_complete
   # Get the command line and current token
@@ -12,9 +12,9 @@ function __fish_aia_complete
   # Check if we are currently completing the option that requires prompt IDs
   if set -q cmd_line[2]
     # Change directory to the prompts directory
-    if test -d $PROMPTS_DIR
-      pushd $PROMPTS_DIR
-      # Generate completions based on .txt files in the PROMPTS_DIR directory
+    if test -d $AIA_PROMPTS_DIR
+      pushd $AIA_PROMPTS_DIR
+      # Generate completions based on .txt files in the AIA_PROMPTS_DIR directory
       for file in (find . -name "*.txt" -type f)
         set file (string replace -r '\.txt$' '' -- $file)
         set file (string replace -r '^\./' '' -- $file)

--- a/lib/aia/aia_completion.zsh
+++ b/lib/aia/aia_completion.zsh
@@ -3,7 +3,7 @@
 # the zsh shell
 #
 # This script assumes that the system environment
-# variable PROMPTS_DIR has been set correctly
+# variable AIA_PROMPTS_DIR has been set correctly
 
 _aia_completion() {
   # The current word being completed
@@ -18,7 +18,7 @@ _aia_completion() {
   # Check if we are currently completing the option that requires prompt IDs
   if [[ "$prev_word" == "aia" ]]; then
     # Change directory to the prompts directory
-    cd "$PROMPTS_DIR" || return
+    cd "$AIA_PROMPTS_DIR" || return
 
     # Generate a list of relative paths from the ~/.prompts directory (without .txt extension)
     local files=($(find . -name "*.txt" -type f | sed 's|^\./||' | sed 's/\.txt$//'))


### PR DESCRIPTION
When the envars were changed to have the AIA_ prefix the completion functions were forgotten.  This PR changes the $PROMPTS_DIR in those functions to $AIA_PROMPTS_DIR