### PR TITLE
Issue 24 wrap text to STDOUT make it look better

### DIFF
--- a/.semver
+++ b/.semver
@@ -1,6 +1,6 @@
 ---
 :major: 0
 :minor: 5
-:patch: 1
+:patch: 2
 :special: ''
 :metadata: ''

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## [Unreleased]
 
+## [0.5.2] 2024-01-13
+- wrap response when its going to the terminal
+
 ## [0.5.1] 2024-01-12
 - removed a wicked puts "loaded" statement
 - fixed missed code when the options were changed to --out_file and --log_file

--- a/lib/aia/main.rb
+++ b/lib/aia/main.rb
@@ -56,6 +56,11 @@ class AIA::Main
 
   # Function to prompt the user with a question using reline
   def ask_question_with_reline(prompt)
+    if prompt.start_with?("\n")
+      puts
+      prompt = prompt[1..]
+    end
+
     answer = Reline.readline(prompt)
     Reline::HISTORY.push(answer) unless answer.nil? || Reline::HISTORY.to_a.include?(answer)
     answer
@@ -109,6 +114,12 @@ class AIA::Main
 
     result  = backend.run
 
+    if STDOUT == AIA.config.out_file
+      result  = result.wrap(indent: 2)
+    end
+
+    # TODO: consider using glow to render markdown to
+    #       terminal `brew install glow`
     AIA.config.out_file.write result
 
     logger.prompt_result(@prompt, result)
@@ -139,7 +150,7 @@ class AIA::Main
       
       speak response
 
-      puts "\nResponse: #{response}"
+      puts "\nResponse:\n#{response.wrap(indent: 2)}"
       logger.info "Response: #{backend.run}"
   
       # TODO: Allow user to enter a directive; loop

--- a/lib/aia/prompt.rb
+++ b/lib/aia/prompt.rb
@@ -150,6 +150,11 @@ class AIA::Prompt
 
   # Function to prompt the user with a question using reline
   def ask_question_with_reline(prompt)
+    if prompt.start_with?("\n")
+      puts
+      prompt = prompt[1..]
+    end
+
     answer = Reline.readline(prompt)
     Reline::HISTORY.push(answer) unless answer.nil? || Reline::HISTORY.to_a.include?(answer)
     answer
@@ -178,7 +183,7 @@ class AIA::Prompt
     if default&.empty?
       user_prompt = "\n-=> "
     else
-      user_prompt = "\n(#{default}) -=>"
+      user_prompt = "\n(#{default}) -=> "
     end
 
     a_string = ask_question_with_reline(user_prompt)


### PR DESCRIPTION
Fixed a problem where the Reline.readline("\nFollow Up: ") command was not honoring the initial newline character.  That is a problem in the reline gem.  Added a work around to aia.

wrap with an indent: 2 is now called for responses being directed to  STDOUT.