### PR TITLE
issue 19 - making directives, shell integration and ERB dynamic content available in chat sessions

### DIFF
--- a/.semver
+++ b/.semver
@@ -1,6 +1,6 @@
 ---
 :major: 0
 :minor: 5
-:patch: 5
+:patch: 6
 :special: ''
 :metadata: ''

--- a/.semver
+++ b/.semver
@@ -1,6 +1,6 @@
 ---
 :major: 0
 :minor: 5
-:patch: 4
+:patch: 5
 :special: ''
 :metadata: ''

--- a/.semver
+++ b/.semver
@@ -1,6 +1,6 @@
 ---
 :major: 0
 :minor: 5
-:patch: 3
+:patch: 4
 :special: ''
 :metadata: ''

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 ## [Unreleased]
+
+## [0.5.6] 2024-01-15
 - Adding processing for directives, shell integration and erb to the follow up prompt in a chat session
 - some code refactoring.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 ## [Unreleased]
+- Adding processing for directives, shell integration and erb to the follow up prompt in a chat session
+- some code refactoring.
 
 ## [0.5.3] 2024-01-14
 - adding ability to render markdown to the terminal using the "glow" CLI utility

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ It leverages the `prompt_manager` gem to manage prompts for the `mods` and `sgpt
 
 **Most Recent Change**: Refer to the [Changelog](CHANGELOG.md)
 v0.5.6
-- Directives within a chat session follow up are not available
+- Directives within a chat session follow up are now available
 - when the `--shell` option is set access to envars and shell scripts are availabe in a chat session follow up prompt
 - when the `--erb` option is set, access to ERB-based dynamic content is available in a chat session follow up prompt.
 

--- a/README.md
+++ b/README.md
@@ -5,6 +5,11 @@
 It leverages the `prompt_manager` gem to manage prompts for the `mods` and `sgpt` CLI utilities. It utilizes "ripgrep" for searching for prompt files.  It uses `fzf` for prompt selection based on a search term and fuzzy matching.
 
 **Most Recent Change**: Refer to the [Changelog](CHANGELOG.md)
+v0.5.6
+- Directives within a chat session follow up are not available
+- when the `--shell` option is set access to envars and shell scripts are availabe in a chat session follow up prompt
+- when the `--erb` option is set, access to ERB-based dynamic content is available in a chat session follow up prompt.
+
 v0.5.3
 - `--render` will render markdown formatted content to the terminal using the `glow` CLI utility.
 - fixes to some terminal UI stuff like AI response is not being wrapped to the terminal width to make for easier reading.
@@ -25,11 +30,14 @@ v0.5.0 - Breaking changes:
   - [Shell Integration inside of a Prompt](#shell-integration-inside-of-a-prompt)
       - [Access to System Environment Variables](#access-to-system-environment-variables)
       - [Dynamic Shell Commands](#dynamic-shell-commands)
+      - [Chat Session Use](#chat-session-use)
   - [*E*mbedded *R*u*B*y (ERB)](#embedded-ruby-erb)
+    - [Chat Session Behavior](#chat-session-behavior)
   - [Prompt Directives](#prompt-directives)
     - [`aia` Specific Directive Commands](#aia-specific-directive-commands)
       - [//config](#config)
     - [Backend Directive Commands](#backend-directive-commands)
+    - [Using Directives in Chat Sessions](#using-directives-in-chat-sessions)
   - [All About ROLES](#all-about-roles)
     - [Other Ways to Insert Roles into Prompts](#other-ways-to-insert-roles-into-prompts)
   - [External CLI Tools Used](#external-cli-tools-used)
@@ -101,7 +109,15 @@ ARGUMENTS
 
 OPTIONS
        --chat begin a chat session with the backend after the initial prompt response;  will
-              set --no-out_file so that the backend response comes to STDOUT.
+              set --no-out_file so that the backend response comes to STDOUT.  After the
+              initial prompt is processed, you will be asked to provide a follow up.  Just
+              enter whatever is appropriate terminating your input with a RETURN.  The
+              backend will provide a response to you follow up and ask you again if you have
+              another follow up. This back and forth chatting will continue until you enter a
+              RETURN without any other content - an empty follow up prompt.  You may also
+              enter a directive to be processed after which another follow up is requested.
+              If you have the --shell and/or the --erb options set you may use those tools
+              within your follow up to provide dynamic content.
 
        --completion SHELL_NAME
 
@@ -280,6 +296,7 @@ AUTHOR
 AIA                                       2024-01-01                                   aia(1)
 ```
 
+
 ## Configuration Using Envars
 
 The `aia` configuration defaults can be over-ridden by system environment variables *(envars)* with the prefix "AIA_" followed by the config item name also in uppercase. All configuration items can be over-ridden in this way by an envar.  The following table show a few examples.
@@ -328,6 +345,15 @@ or insert content from a file in your home directory:
 Given the following constraints $(cat ~/3_laws_of_robotics.txt) determine the best way to instruct my roomba to clean my kids room.
 ```
 
+#### Chat Session Use
+
+When you use the `--shell` option to start a chat session, shell integration is available in your follow up prompts.  Suppose you started up a chat session using a roll of "Ruby Expert" expecting to chat about changes that could be made to a specific class BUT you forgot to include the class source file as part of the context when you got started.  You could enter this as your follow up prompt to this to keep going:
+
+```
+The class I want to chat about refactoring is this one: $(cat my_class.rb)
+```
+
+That inserts the entire class source file into your follow up prompt.  You can continue chatting with you AI Assistant avout changes to the class.
 
 ## *E*mbedded *R*u*B*y (ERB)
 
@@ -337,6 +363,11 @@ The `--erb` option turns the prompt text file into a fully functioning ERB templ
 
 Most websites that have information about ERB will give examples of how to use ERB to generate dynamice HTML content for web-based applications.  That is a common use case for ERB.  `aia` on the other hand uses ERB to generate dynamic prompt text.
 
+### Chat Session Behavior
+
+In a chat session whether started by the `--chat` option or its equivalent with a directive within a prompt text file behaves a little differently w/r/t its binding and local variable assignments.  Since a chat session by definition has multiple prompts, setting a local variable in one prompt and expecting it to be available in a subsequent prompt does not work.  You need to use instance variables to accomplish this prompt to prompt carry over of information.
+
+Also since follow up prompts are expected to be a single thing - sentence or paragraph - terminated by a single return, its likely that ERB enhance will be of benefit; but, you may find a use for it.
 
 ## Prompt Directives
 
@@ -389,6 +420,17 @@ FOr example `mods` has a configuration item `topp` which can be set by a directi
 ```
 
 If `mods` is not the backend the `//topp` direcive is ignored.
+
+### Using Directives in Chat Sessions
+
+Whe you are in a chat session, you may use a directive as a follow up prompt.  For example if you started the chat session with the option `--terse` expecting to get short answers from the backend; but, then you decide that you want more comprehensive answers you may do this:
+
+```
+//config terse? false
+```
+
+The directive is executed and a new follow up prompt can be entered with a more lengthy response generated from the backend.
+
 
 ## All About ROLES
 

--- a/lib/aia/directives.rb
+++ b/lib/aia/directives.rb
@@ -2,13 +2,15 @@
 
 require 'hashie'
 
+=begin
+  AIA.config.directives is an Array of Arrays.  An
+  entry looks like this:
+    [directive, parameters]
+  where both are String objects
+=end
+
+
 class AIA::Directives
-  def initialize( prompt: )
-    @prompt = prompt  # PromptManager::Prompt instance
-    AIA.config.directives = @prompt.directives
-  end
-
-
   def execute_my_directives
     return if AIA.config.directives.nil? || AIA.config.directives.empty?
     

--- a/lib/aia/dynamic_content.rb
+++ b/lib/aia/dynamic_content.rb
@@ -1,0 +1,26 @@
+# aia/lib/aia/dynamic_content.rb
+
+require 'erb'
+
+module AIA::DynamicContent
+
+  # inserts environment variables (envars) and dynamic content into a prompt
+  # replaces patterns like $HOME and ${HOME} with the value of ENV['HOME']
+  # replaces patterns like $(shell command) with the output of the shell command
+  #
+  def render_env(a_string)
+    a_string.gsub(/\$(\w+|\{\w+\})/) do |match|
+      ENV[match.tr('$', '').tr('{}', '')]
+    end.gsub(/\$\((.*?)\)/) do |match|
+      `#{match[2..-2]}`.chomp
+    end
+  end
+
+
+  # Need to use instance variables in assignments
+  # to maintain binding from one follow up prompt
+  # to another.
+  def render_erb(the_prompt_text)
+    ERB.new(the_prompt_text).result(binding)
+  end
+end

--- a/lib/aia/main.rb
+++ b/lib/aia/main.rb
@@ -5,6 +5,7 @@ module AIA ; end
 require_relative 'config'
 require_relative 'cli'
 require_relative 'directives'
+require_relative 'dynamic_content'
 require_relative 'prompt'
 require_relative 'logging'
 require_relative 'tools'
@@ -13,6 +14,7 @@ require_relative 'tools'
 # of a single class.
 
 class AIA::Main
+  include AIA::DynamicContent
 
   attr_accessor :logger, :tools, :backend
 
@@ -169,27 +171,6 @@ class AIA::Main
     end
 
     a_string
-  end
-
-
-  # Need to use instance variables in assignments
-  # to maintain binding from one follow up prompt
-  # to another.
-  def render_erb(the_prompt_text)
-    ERB.new(the_prompt_text).result(binding)
-  end
-
-
-  # inserts environment variables (envars) and dynamic content into a prompt
-  # replaces patterns like $HOME and ${HOME} with the value of ENV['HOME']
-  # replaces patterns like $(shell command) with the output of the shell command
-  #
-  def render_env(a_string)
-    a_string.gsub(/\$(\w+|\{\w+\})/) do |match|
-      ENV[match.tr('$', '').tr('{}', '')]
-    end.gsub(/\$\((.*?)\)/) do |match|
-      `#{match[2..-2]}`.chomp
-    end
   end
 
   

--- a/lib/aia/main.rb
+++ b/lib/aia/main.rb
@@ -172,18 +172,12 @@ class AIA::Main
   end
 
 
-  def handle_erb(the_prompt_text)
-    # TODO: evaluate ERB within the string.  don't worry about
-    #       being dry and using a method in a different class
-    # NOTE: The binding context may change completely.  will need
-    #       to test that be setting a variable in one follow up and
-    #       accessing it in another.
-
-    the_prompt_text
+  def render_erb(the_prompt_text)
+    ERB.new(the_prompt_text).result(binding)
   end
 
 
-  def handle_shall(the_prompt_text)
+  def handle_shell(the_prompt_text)
     # TODO: process the shell integration
 
     the_prompt_text
@@ -212,7 +206,7 @@ class AIA::Main
     the_prompt_text = ask_question_with_reline("\nFollow Up: ")
 
     until the_prompt_text.empty?
-      the_prompt_text   = handle_erb(   the_prompt_text) if AIA.config.erb?
+      the_prompt_text   = render_erb(   the_prompt_text) if AIA.config.erb?
       the_prompt_text   = handle_shell( the_prompt_text) if AIA.config.shell?
 
       unless handle_directives(the_prompt_text)

--- a/lib/aia/main.rb
+++ b/lib/aia/main.rb
@@ -171,30 +171,50 @@ class AIA::Main
   end
 
 
+  def handle_erb(the_prompt_text)
+    # TODO: evaluate ERB
+    
+    the_prompt_text
+  end
+
+
+  def handle_shall(the_prompt_text)
+    # TODO: process the shell integration
+
+    the_prompt_text
+  end
+
+  
+  def handle_directives(the_prompt_text)
+    result = the_prompt_text.start_with?(AIA::Prompt::DIRECTIVE_SIGNAL)
+
+    if result
+      # TODO: get the directives class to handle this directive
+      # TODO: if its still here pass the directive to the backend for handling
+    end
+  
+    result
+  end
+
+
   def lets_chat
     add_continue_option    
 
     the_prompt_text = ask_question_with_reline("\nFollow Up: ")
-    
+
     until the_prompt_text.empty?
-      the_prompt_text = insert_terse_phrase(the_prompt_text)
-      
-      result = get_and_display_result(the_prompt_text)
+      the_prompt_text   = handle_erb(   the_prompt_text) if AIA.config.erb?
+      the_prompt_text   = handle_shell( the_prompt_text) if AIA.config.shell?
 
-      log_the_follow_up(the_prompt_text, result)
+      unless handle_directives(the_prompt_text)
+        the_prompt_text = insert_terse_phrase(the_prompt_text)
+        result          = get_and_display_result(the_prompt_text)
 
-      speak result
+        log_the_follow_up(the_prompt_text, result)
+        speak result
+      end
 
-
-      # TODO: Allow user to enter a directive; loop
-      #       until answer is not a directive
-      #
-      # while !directive do
-      
       the_prompt_text = ask_question_with_reline("\nFollow Up: ")
-      
-      # execute the directive
-      # end
     end
   end
 end

--- a/lib/aia/prompt.rb
+++ b/lib/aia/prompt.rb
@@ -42,7 +42,7 @@ class AIA::Prompt
 
     if build
       @prompt.text = render_erb(@prompt.text)   if AIA.config.erb?
-      @prompt.text = replace_env(@prompt.text)  if AIA.config.shell?
+      @prompt.text = render_env(@prompt.text)   if AIA.config.shell?
       process_prompt 
     end
 
@@ -95,11 +95,11 @@ class AIA::Prompt
   end
 
 
-  # inserts environmant variables and dynamic content into a prompt
+  # inserts environment variables (envars) and dynamic content into a prompt
   # replaces patterns like $HOME and ${HOME} with the value of ENV['HOME']
   # replaces patterns like $(shell command) with the output of the shell command
   #
-  def replace_env(a_string)
+  def render_env(a_string)
     a_string.gsub(/\$(\w+|\{\w+\})/) do |match|
       ENV[match.tr('$', '').tr('{}', '')]
     end.gsub(/\$\((.*?)\)/) do |match|

--- a/lib/aia/prompt.rb
+++ b/lib/aia/prompt.rb
@@ -1,9 +1,12 @@
 # lib/aia/prompt.rb
 
 require 'reline'
-require 'erb'
+
+require_relative 'dynamic_content'
 
 class AIA::Prompt
+  include AIA::DynamicContent
+
   #
   # used when no prompt_id is provided but there
   # are extra parameters that need to be passed
@@ -92,25 +95,6 @@ class AIA::Prompt
     @prompt.text  = original_text
     @prompt.save
     @prompt.text  = temp_text
-  end
-
-
-  # inserts environment variables (envars) and dynamic content into a prompt
-  # replaces patterns like $HOME and ${HOME} with the value of ENV['HOME']
-  # replaces patterns like $(shell command) with the output of the shell command
-  #
-  def render_env(a_string)
-    a_string.gsub(/\$(\w+|\{\w+\})/) do |match|
-      ENV[match.tr('$', '').tr('{}', '')]
-    end.gsub(/\$\((.*?)\)/) do |match|
-      `#{match[2..-2]}`.chomp
-    end
-  end
-
-
-  # You are just asking for trouble!
-  def render_erb(a_string)
-    ERB.new(a_string).result(binding)
   end
 
 

--- a/lib/aia/prompt.rb
+++ b/lib/aia/prompt.rb
@@ -45,6 +45,8 @@ class AIA::Prompt
       @prompt.text = replace_env(@prompt.text)  if AIA.config.shell?
       process_prompt 
     end
+
+    AIA.config.directives = @prompt.directives
   end
 
 

--- a/lib/aia/tools/backend_common.rb
+++ b/lib/aia/tools/backend_common.rb
@@ -12,9 +12,12 @@ module AIA::BackendCommon
     build_command
   end
 
+
   def sanitize(input)
     Shellwords.escape(input)
   end
+
+
   def build_command
     @parameters += " --model #{AIA.config.model} " if AIA.config.model
     @parameters += AIA.config.extra
@@ -29,6 +32,7 @@ module AIA::BackendCommon
     @command
   end
 
+
   def set_parameter_from_directives
     AIA.config.directives.each do |entry|
       directive, value = entry
@@ -38,6 +42,7 @@ module AIA::BackendCommon
     end
   end
 
+
   def run
     case @files.size
     when 0
@@ -45,32 +50,9 @@ module AIA::BackendCommon
     when 1
       @result = `#{build_command} < #{@files.first}`
     else
-      create_temp_file_with_contexts
-      run_with_temp_file
-      clean_up_temp_file
+      @result = %x[cat #{@files.join(' ')} | #{build_command}]
     end
 
     @result
-  end
-
-  def create_temp_file_with_contexts
-    @temp_file = Tempfile.new("#{self.class::COMMAND_NAME}-context")
-
-    @files.each do |file|
-      content = File.read(file)
-      @temp_file.write(content)
-      @temp_file.write("\n")
-    end
-
-    @temp_file.close
-  end
-
-  def run_with_temp_file
-    command = "#{build_command} < #{@temp_file.path}"
-    @result = `#{command}`
-  end
-
-  def clean_up_temp_file
-    @temp_file.unlink if @temp_file
   end
 end

--- a/man/aia.1
+++ b/man/aia.1
@@ -23,7 +23,7 @@ External options are optional\.  Anything that follow \[lq] \-\- \[lq] will be s
 .SH OPTIONS
 .TP
 \fB\-\-chat\fR
-begin a chat session with the backend after the initial prompt response;  will set \-\-no\-out\[ru]file so that the backend response comes to STDOUT\.
+begin a chat session with the backend after the initial prompt response;  will set \-\-no\-out\[ru]file so that the backend response comes to STDOUT\.  After the initial prompt is processed, you will be asked to provide a follow up\.  Just enter whatever is appropriate terminating your input with a RETURN\.  The backend will provide a response to you follow up and ask you again if you have another follow up\. This back and forth chatting will continue until you enter a RETURN without any other content \- an empty follow up prompt\.  You may also enter a directive to be processed after which another follow up is requested\.  If you have the \fB\-\-shell\fR and\[sl]or the \fB\-\-erb\fR options set you may use those tools within your follow up to provide dynamic content\.
 .TP
 \fB\-\-completion\fR \fISHELL\[ru]NAME\fP
 .TP

--- a/man/aia.1.md
+++ b/man/aia.1.md
@@ -26,7 +26,7 @@ The aia command-line tool is an interface for interacting with an AI model backe
 ## OPTIONS
 
 `--chat`
-: begin a chat session with the backend after the initial prompt response;  will set --no-out_file so that the backend response comes to STDOUT.
+: begin a chat session with the backend after the initial prompt response;  will set --no-out_file so that the backend response comes to STDOUT.  After the initial prompt is processed, you will be asked to provide a follow up.  Just enter whatever is appropriate terminating your input with a RETURN.  The backend will provide a response to you follow up and ask you again if you have another follow up. This back and forth chatting will continue until you enter a RETURN without any other content - an empty follow up prompt.  You may also enter a directive to be processed after which another follow up is requested.  If you have the `--shell` and/or the `--erb` options set you may use those tools within your follow up to provide dynamic content.
 
 `--completion` *SHELL_NAME*
 : Show completion script for bash|zsh|fish - default is nil

--- a/test/aia/directives_test.rb
+++ b/test/aia/directives_test.rb
@@ -3,17 +3,9 @@
 require_relative  '../test_helper'
 
 class DirectivesTest < Minitest::Test
-  # Utility Class for a Prompt Mock
-  class MockPrompt
-    def directives
-      []
-    end
-  end
-
-
   def setup
     AIA::Cli.new("")
-    @ad = AIA::Directives.new(prompt: MockPrompt.new)
+    @ad = AIA::Directives.new
   end
 
 


### PR DESCRIPTION
- removed unused methods associated with the previous use of a temp file when dealing with more than one context file.
- now supports directives entered in the follow up prompt
- updated directives test suite
- erb in follow up prompts is working
- shell intergration for follow up prompts is working
- extracted common methods from the Main and Prompt classes into a DynamicContent module.
- ready for relese of v0.5.6
