### PR TITLE
issue 29 added ERB processing of config file

### DIFF
--- a/.semver
+++ b/.semver
@@ -1,6 +1,6 @@
 ---
 :major: 0
 :minor: 5
-:patch: 6
+:patch: 7
 :special: ''
 :metadata: ''

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 ## [Unreleased]
+## [0.5.7] 2024-01-15
+- Added ERB processing to the config_file
 
 ## [0.5.6] 2024-01-15
 - Adding processing for directives, shell integration and erb to the follow up prompt in a chat session

--- a/README.md
+++ b/README.md
@@ -5,6 +5,9 @@
 It leverages the `prompt_manager` gem to manage prompts for the `mods` and `sgpt` CLI utilities. It utilizes "ripgrep" for searching for prompt files.  It uses `fzf` for prompt selection based on a search term and fuzzy matching.
 
 **Most Recent Change**: Refer to the [Changelog](CHANGELOG.md)
+v0.5.7
+- Added ERB processing to config files that have the pattern any_file.ext.erb where ext is the real extension of the file.
+
 v0.5.6
 - Directives within a chat session follow up are now available
 - when the `--shell` option is set access to envars and shell scripts are availabe in a chat session follow up prompt
@@ -163,7 +166,10 @@ OPTIONS
               Specify the backend prompt resolver - default is mods
 
        -c, --config_file PATH_TO_CONFIG_FILE
-              Load Config File - default is nil
+              Load Config File. both YAML and TOML formats are supported.  Also ERB is
+              supported.  For example ~/aia_config.yml.erb will be processed through ERB and
+              then through YAML.  The result will be written out to ~/aia_config.yml so that
+              you can manually verify that you got what you wanted from the ERB processing.
 
        -d, --debug
               Turn On Debugging - default is false

--- a/lib/aia/cli.rb
+++ b/lib/aia/cli.rb
@@ -97,7 +97,19 @@ class AIA::Cli
   end
 
 
+  def replace_erb_in_config_file
+    content = Pathname.new(AIA.config.config_file).read
+    content = ERB.new(content).result(binding)
+    AIA.config.config_file  = AIA.config.config_file.to_s.gsub('.erb', '')
+    Pathname.new(AIA.config.config_file).write content
+  end
+
+
   def load_config_file
+    if AIA.config.config_file.to_s.end_with?(".erb")
+      replace_erb_in_config_file
+    end
+
     AIA.config.config_file = Pathname.new(AIA.config.config_file)
     if AIA.config.config_file.exist?
       AIA.config.merge! parse_config_file

--- a/man/aia.1
+++ b/man/aia.1
@@ -57,7 +57,7 @@ Print Version \- default is false
 Specify the backend prompt resolver \- default is mods
 .TP
 \fB\-c\fR, \fB\-\-config\[ru]file\fR \fIPATH\[ru]TO\[ru]CONFIG\[ru]FILE\fP
-Load Config File \- default is nil
+Load Config File\. both YAML and TOML formats are supported\.  Also ERB is supported\.  For example \[ti]\[sl]aia\[ru]config\.yml\.erb will be processed through ERB and then through YAML\.  The result will be written out to \[ti]\[sl]aia\[ru]config\.yml so that you can manually verify that you got what you wanted from the ERB processing\.
 .TP
 \fB\-d\fR, \fB\-\-debug\fR
 Turn On Debugging \- default is false

--- a/man/aia.1.md
+++ b/man/aia.1.md
@@ -62,7 +62,7 @@ The aia command-line tool is an interface for interacting with an AI model backe
 : Specify the backend prompt resolver - default is mods
 
 `-c`, `--config_file` *PATH_TO_CONFIG_FILE*
-: Load Config File - default is nil
+: Load Config File. both YAML and TOML formats are supported.  Also ERB is supported.  For example ~/aia_config.yml.erb will be processed through ERB and then through YAML.  The result will be written out to ~/aia_config.yml so that you can manually verify that you got what you wanted from the ERB processing.
 
 `-d`, `--debug`
 : Turn On Debugging - default is false

--- a/test/aia/config_files/.gitignore
+++ b/test/aia/config_files/.gitignore
@@ -1,0 +1,1 @@
+test_config.yml

--- a/test/aia/config_files/test_config.yml.erb
+++ b/test/aia/config_files/test_config.yml.erb
@@ -1,0 +1,1 @@
+configuration: <%= "value" %>


### PR DESCRIPTION
- added ERB processing for a config file
- bumped version
- preped for release

A file like ~/aia_config.yml.erb will be processed through ERB and then trhough YAML to set the configuration.  A file ~/aia_config.yml will be written out with the ERB remobed.
